### PR TITLE
Exit cleanly on Ctrl-C

### DIFF
--- a/ext_http_server.py
+++ b/ext_http_server.py
@@ -259,6 +259,10 @@ class SecureHTTPServer(HTTPServer):
 class MyServer(socketserver.ThreadingMixIn, SecureHTTPServer):
     """A threaded SecureHTTPServer with basic error filtering."""
 
+    # Run connection threads as daemons so a lingering HTTP/1.1 keep-alive
+    # connection cannot block interpreter shutdown on Ctrl-C (see issue #1).
+    daemon_threads = True
+
     def handle_error(self, request: socket | tuple[bytes, socket], client_address: Any) -> None:  # noqa: ANN401
         """Disable tracebacks on connection close errors."""
         _, exc_value, _ = sys.exc_info()
@@ -317,6 +321,8 @@ def main() -> int:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\nGoodbye")
+    finally:
+        server.server_close()
     return 0
 
 

--- a/tests/test_ext_http_server.py
+++ b/tests/test_ext_http_server.py
@@ -156,6 +156,12 @@ def test_server_serves_range_request(secure_server):
     assert body == b"56789ABCDEFGHIJ"
 
 
+def test_server_uses_daemon_threads():
+    # Daemon connection threads keep lingering keep-alive connections from
+    # blocking interpreter shutdown on Ctrl-C (see issue #1).
+    assert MyServer.daemon_threads is True
+
+
 def test_set_rate_limit_computes_block_size():
     RateLimitWriter.set_rate_limit(128)
     assert RateLimitWriter.block_size == int(1024 * 128 * RateLimitWriter.INTERVAL_LEN)


### PR DESCRIPTION
## Problem

Fixes #1. Starting the server, opening a page in a browser, then pressing Ctrl-C printed "Goodbye" but the process never exited.

## Cause

`MyServer` uses `ThreadingMixIn`, whose default is `daemon_threads = False`. Since `RangeHandler.setup` forces `protocol_version = "HTTP/1.1"`, browsers hold **keep-alive** connections open, leaving each worker thread blocked in `recv()`. On Ctrl-C, `serve_forever()` raises `KeyboardInterrupt` and "Goodbye" is printed, but interpreter shutdown then waits on those non-daemon worker threads forever — hence the hang.

## Fix

- Set `daemon_threads = True` on `MyServer` so lingering connection threads can't block interpreter exit.
- Close the listening socket in a `finally` block for a clean teardown.

## Testing

- Added `test_server_uses_daemon_threads` as a regression guard.
- Full suite passes (`pytest`, 20 passed).
- Manually verified: with an idle keep-alive connection open (`openssl s_client -connect localhost:8080`), Ctrl-C now returns the shell prompt immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)